### PR TITLE
fix opa_check rule when a list of files is passed

### DIFF
--- a/examples/multiple_schema_files/BUILD.bazel
+++ b/examples/multiple_schema_files/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_opa//opa:defs.bzl", "opa_check", "opa_library")
+
+opa_library(
+    name = "multiple_schema_files",
+    srcs = ["main.rego"],
+    strip_prefix = package_name(),
+    visibility = ["//examples:__subpackages__"],
+)
+
+opa_check(
+    name = "multiple_schema_files_check",
+    size = "small",
+    bundle = ":multiple_schema_files",
+    schema_files = [
+        "//examples/simple:schemas/input.json",
+        ":admins.json",
+    ],
+    strict = True,
+)

--- a/examples/multiple_schema_files/admins.json
+++ b/examples/multiple_schema_files/admins.json
@@ -1,0 +1,6 @@
+{
+    "type": "array",
+    "items": {
+        "type": "string"
+    }
+}

--- a/examples/multiple_schema_files/main.rego
+++ b/examples/multiple_schema_files/main.rego
@@ -1,0 +1,14 @@
+# METADATA
+# scope: subpackages
+# schemas:
+#   - input: schema.input
+#   - data.admins: schema.admins
+package main
+
+import future.keywords
+
+allow if {
+	input.name in data.admins
+}
+
+#

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -43,3 +43,5 @@ opa_eval_binary(
     query = "data.main.allow",
     deps = [":simple"],
 )
+
+exports_files(["schemas/input.json"])


### PR DESCRIPTION
It will create a temp dir and copy all the schema files in it.