### PR TITLE
enable code coverage for opa

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -69,6 +69,106 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//opa/private:extensions.bzl%internal_deps": {
+      "general": {
+        "bzlTransitiveDigest": "JF9i2LCJLrQQ03MfzA8kWxJRXbgfWnT73rBS6iXAkqY=",
+        "usagesDigest": "xe0f6AfCl5ChY8B+9jz8VNuqorYB5w9xjE7wtDTiun8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "opa_linux_amd64_static": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_linux_amd64_static",
+              "sha256": "cd6b0b2d762571a746f0261890b155e6dd71cca90dad6b42b6fcf6dd7f619f08",
+              "executable": true,
+              "downloaded_file_path": "opa"
+            }
+          },
+          "opa_linux_arm64_static": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_linux_arm64_static",
+              "sha256": "dba53c4f4a003f5b866e316129a144423900f78093645307ab0c4d20329ccd40",
+              "executable": true,
+              "downloaded_file_path": "opa"
+            }
+          },
+          "opa_darwin_arm64_static": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_darwin_arm64_static",
+              "sha256": "3d8f7e940aa7cf13a532bd095ec5f2d61f7920588675771bfb5da63c3b60cd36",
+              "executable": true,
+              "downloaded_file_path": "opa"
+            }
+          },
+          "opa_windows_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_windows_amd64.exe",
+              "sha256": "6d0c8276487aabb10620d00d4e91d2f76c07a567edc68298ca23d1bc72b93369",
+              "executable": true,
+              "downloaded_file_path": "opa.exe"
+            }
+          },
+          "opa_darwin_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_darwin_amd64",
+              "sha256": "565435206e43a92564093ea85e4001a4a56956476f333367db792a7d693b63c0",
+              "executable": true,
+              "downloaded_file_path": "opa"
+            }
+          },
+          "opa_builtin_metadata_json": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://raw.githubusercontent.com/open-policy-agent/opa/v0.65.0/builtin_metadata.json",
+              "sha256": "47cff9a1f192a3d82c143bef3bc1774f0e7e6cf54a5f6a48371a48631b912424",
+              "downloaded_file_path": "builtin_metadata.json"
+            }
+          },
+          "opa_capabilities_json": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "url": "https://raw.githubusercontent.com/open-policy-agent/opa/v0.65.0/capabilities.json",
+              "sha256": "fdcc65f878bb42838ea1a63a7904cbf67361f0f536a99a61dff11be33357fe8c",
+              "downloaded_file_path": "capabilities.json"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "opa_darwin_amd64",
+            "opa_darwin_arm64_static",
+            "opa_linux_amd64_static",
+            "opa_linux_arm64_static",
+            "opa_windows_amd64",
+            "opa_capabilities_json",
+            "opa_builtin_metadata_json"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",

--- a/opa/private/opa_check.bzl
+++ b/opa/private/opa_check.bzl
@@ -14,7 +14,7 @@ def _opa_check_test_impl(ctx):
     if ctx.files.schema_files:
         files.extend(ctx.files.schema_files)
 
-    args = ["set -xe\n"]
+    args = ["set -e\n"]
 
     args.append(toolchain.opa.short_path)
     args.append("check")

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -18,6 +18,12 @@ py_binary(
     srcs = ["opa_upgrade.py"],
 )
 
+py_binary(
+    name = "opa_coverage",
+    srcs = ["opa_coverage.py"],
+    visibility = ["//visibility:public"],
+)
+
 toolchain_type(name = "toolchain_type")
 
 opa_toolchain(

--- a/tools/opa_coverage.py
+++ b/tools/opa_coverage.py
@@ -91,7 +91,7 @@ def main(argv: List[str]):
             if file in args:
                 continue  # Skip test sources
             print(f"TN:{test_name.removeprefix('@@')}", file=f)
-            print(f"SF:{file}", file=f)
+            print(f"SF:{file.removeprefix('/')}", file=f)
             print(f"FNF:0", file=f)
             print(f"FNH:0", file=f)
 

--- a/tools/opa_coverage.py
+++ b/tools/opa_coverage.py
@@ -1,0 +1,109 @@
+from typing import List, Dict, Any, cast
+from subprocess import run, PIPE
+from dataclasses import dataclass
+from os import environ
+
+import json
+import sys
+
+
+@dataclass
+class CoverageRangeContent:
+    row: int
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(row=data.get("data") or 0)
+
+
+@dataclass
+class CoverageRange:
+    start: CoverageRangeContent
+    end: CoverageRangeContent
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            start=CoverageRangeContent.from_dict(data.get("start")),
+            end=CoverageRangeContent.from_dict(data.get("end")),
+        )
+
+
+@dataclass
+class CoverageFile:
+    covered: List[CoverageRange]
+    not_covered: List[CoverageRange]
+    covered_lines: int
+    not_covered_lines: int
+    coverage: float
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            covered=[CoverageRange.from_dict(r) for r in data.get("covered") or []],
+            not_covered=[
+                CoverageRange.from_dict(r) for r in data.get("not_covered") or []
+            ],
+            covered_lines=int(data.get("covered_lines") or 0),
+            not_covered_lines=int(data.get("not_covered_lines") or 0),
+            coverage=float(data.get("coverage")),
+        )
+
+
+@dataclass
+class CoverageReport:
+    files: Dict[str, CoverageFile]
+    covered_lines: int
+    not_covered_lines: int
+    coverage: float
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            files={
+                file: CoverageFile.from_dict(report)
+                for file, report in data.get("files").items()
+            },
+            covered_lines=int(data.get("covered_lines")),
+            not_covered_lines=int(data.get("not_covered_lines")),
+            coverage=float(data.get("coverage")),
+        )
+
+
+def main(argv: List[str]):
+    _program, test_name, opa, cmd, *args = argv
+
+    coverage_enabled = bool(environ.get("COVERAGE", 0))
+    coverage_output_file = environ.get("COVERAGE_OUTPUT_FILE")
+
+    assert coverage_enabled
+    assert coverage_output_file is not None
+
+    proc = run([opa, cmd, "--format=json", "--coverage"] + args, stdout=PIPE)
+
+    if proc.returncode != 0:
+        exit(proc.returncode)
+
+    result = CoverageReport.from_dict(json.loads(proc.stdout))
+
+    with open(coverage_output_file, "w") as f:
+        for file, report in result.files.items():
+            if file in args:
+                continue  # Skip test sources
+            print(f"TN:{test_name.removeprefix('@@')}", file=f)
+            print(f"SF:{file}", file=f)
+            print(f"FNF:0", file=f)
+            print(f"FNH:0", file=f)
+
+            for r in report.covered:
+                for i in range(r.start.row, r.end.row + 1):
+                    print(f"DA:{i},1", file=f)
+
+            print(f"LF:{report.covered_lines+report.not_covered_lines}", file=f)
+            print(f"LH:{report.covered_lines}", file=f)
+            print("end_of_record", file=f)
+            print(file=f)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Add code coverage support for `opa_test`

```shell
#!/usr/bin/env nix-shell
#!nix-shell -i bash -p bash lcov

bazel coverage //examples/... --combined_report=lcov
cd examples/simple # see strip_prefix
genhtml ../../bazel-out/_coverage/_coverage/_coverage_report.data
```




Closes https://github.com/ticketmaster/rules_opa/issues/50